### PR TITLE
feat: エラーハンドリング・URL検証・ログ出力・ヘルスチェックを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# URL Shortener 環境変数設定例
+# このファイルを .env にコピーして値を設定してください
+
+# APIサーバーのポート番号（デフォルト: 8080）
+PORT=8080
+
+# APIサーバーのベースURL（短縮URLの生成に使用）
+# 本番環境では実際のドメインに変更してください
+BASE_URL=http://localhost:8080
+
+# アナリティクスサービスが接続するAPIサーバーのURL
+# docker-compose 使用時は http://api-server:8080 に変更してください
+API_URL=http://localhost:8080

--- a/analytics/client.py
+++ b/analytics/client.py
@@ -1,6 +1,15 @@
 """Client for communicating with the URL Shortener API server."""
 
 import requests
+from requests.exceptions import ConnectionError, Timeout, RequestException
+
+
+class APIError(Exception):
+    """APIサーバーとの通信エラーを表す例外"""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class APIClient:
@@ -8,22 +17,67 @@ class APIClient:
         self.base_url = base_url.rstrip("/")
 
     def shorten(self, url: str) -> dict:
-        resp = requests.post(
-            f"{self.base_url}/api/shorten",
-            json={"url": url},
-            timeout=10,
-        )
-        resp.raise_for_status()
-        return resp.json()
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/shorten",
+                json={"url": url},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except ConnectionError:
+            raise APIError(
+                f"APIサーバーに接続できません: {self.base_url}\nサーバーが起動しているか確認してください。"
+            )
+        except Timeout:
+            raise APIError("APIサーバーへのリクエストがタイムアウトしました。")
+        except requests.HTTPError as e:
+            try:
+                detail = e.response.json().get("error", str(e))
+            except Exception:
+                detail = str(e)
+            raise APIError(f"APIエラー: {detail}", status_code=e.response.status_code)
+        except RequestException as e:
+            raise APIError(f"ネットワークエラー: {e}")
 
     def get_stats(self) -> dict:
-        resp = requests.get(f"{self.base_url}/api/stats", timeout=10)
-        resp.raise_for_status()
-        return resp.json()
+        try:
+            resp = requests.get(f"{self.base_url}/api/stats", timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except ConnectionError:
+            raise APIError(
+                f"APIサーバーに接続できません: {self.base_url}\nサーバーが起動しているか確認してください。"
+            )
+        except Timeout:
+            raise APIError("APIサーバーへのリクエストがタイムアウトしました。")
+        except requests.HTTPError as e:
+            try:
+                detail = e.response.json().get("error", str(e))
+            except Exception:
+                detail = str(e)
+            raise APIError(f"APIエラー: {detail}", status_code=e.response.status_code)
+        except RequestException as e:
+            raise APIError(f"ネットワークエラー: {e}")
 
     def get_url_stats(self, short_code: str) -> dict:
-        resp = requests.get(
-            f"{self.base_url}/api/stats/{short_code}", timeout=10
-        )
-        resp.raise_for_status()
-        return resp.json()
+        try:
+            resp = requests.get(
+                f"{self.base_url}/api/stats/{short_code}", timeout=10
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except ConnectionError:
+            raise APIError(
+                f"APIサーバーに接続できません: {self.base_url}\nサーバーが起動しているか確認してください。"
+            )
+        except Timeout:
+            raise APIError("APIサーバーへのリクエストがタイムアウトしました。")
+        except requests.HTTPError as e:
+            try:
+                detail = e.response.json().get("error", str(e))
+            except Exception:
+                detail = str(e)
+            raise APIError(f"APIエラー: {detail}", status_code=e.response.status_code)
+        except RequestException as e:
+            raise APIError(f"ネットワークエラー: {e}")

--- a/analytics/main.py
+++ b/analytics/main.py
@@ -3,7 +3,7 @@
 import argparse
 import sys
 
-from client import APIClient
+from client import APIClient, APIError
 from analyzer import generate_report, top_urls_by_clicks, extract_domains
 
 
@@ -27,31 +27,36 @@ def main():
 
     client = APIClient(args.api_url)
 
-    if args.command == "report":
-        stats = client.get_stats()
-        print(generate_report(stats))
+    try:
+        if args.command == "report":
+            stats = client.get_stats()
+            print(generate_report(stats))
 
-    elif args.command == "top":
-        stats = client.get_stats()
-        entries = stats.get("entries") or []
-        for entry in top_urls_by_clicks(entries):
-            print(f"  {entry['short_code']}  {entry['clicks']:>5} clicks  {entry['original_url']}")
+        elif args.command == "top":
+            stats = client.get_stats()
+            entries = stats.get("entries") or []
+            for entry in top_urls_by_clicks(entries):
+                print(f"  {entry['short_code']}  {entry['clicks']:>5} clicks  {entry['original_url']}")
 
-    elif args.command == "domains":
-        stats = client.get_stats()
-        entries = stats.get("entries") or []
-        for domain, count in extract_domains(entries).most_common(10):
-            print(f"  {domain:<30} {count:>5} URLs")
+        elif args.command == "domains":
+            stats = client.get_stats()
+            entries = stats.get("entries") or []
+            for domain, count in extract_domains(entries).most_common(10):
+                print(f"  {domain:<30} {count:>5} URLs")
 
-    elif args.command == "lookup":
-        entry = client.get_url_stats(args.code)
-        print(f"  Code:     {entry['short_code']}")
-        print(f"  URL:      {entry['original_url']}")
-        print(f"  Clicks:   {entry['clicks']}")
-        print(f"  Created:  {entry['created_at']}")
+        elif args.command == "lookup":
+            entry = client.get_url_stats(args.code)
+            print(f"  Code:     {entry['short_code']}")
+            print(f"  URL:      {entry['original_url']}")
+            print(f"  Clicks:   {entry['clicks']}")
+            print(f"  Created:  {entry['created_at']}")
 
-    else:
-        parser.print_help()
+        else:
+            parser.print_help()
+            sys.exit(1)
+
+    except APIError as e:
+        print(f"エラー: {e}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/api-server/main.go
+++ b/api-server/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -110,6 +111,46 @@ func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 	json.NewEncoder(w).Encode(data)
 }
 
+// validateURL はURLが有効かつhttp/httpsスキームを持つかを検証する
+func validateURL(rawURL string) error {
+	if rawURL == "" {
+		return fmt.Errorf("URLは必須です")
+	}
+	parsed, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return fmt.Errorf("URLの形式が無効です: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("URLはhttpまたはhttpsスキームである必要があります")
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("URLにホスト名が必要です")
+	}
+	return nil
+}
+
+// loggingMiddleware はHTTPリクエストをログ出力するミドルウェア
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(wrapped, r)
+		duration := time.Since(start)
+		log.Printf("%s %s %d %s %s", r.Method, r.URL.Path, wrapped.statusCode, duration, r.RemoteAddr)
+	})
+}
+
+// responseWriter はステータスコードをキャプチャするためのラッパー
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
 func main() {
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -141,8 +182,8 @@ func main() {
 			return
 		}
 
-		if req.URL == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "url is required"})
+		if err := validateURL(req.URL); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
 
@@ -198,5 +239,5 @@ func main() {
 	})
 
 	log.Printf("URL Shortener API server starting on port %s", port)
-	log.Fatal(http.ListenAndServe(":"+port, mux))
+	log.Fatal(http.ListenAndServe(":"+port, loggingMiddleware(mux)))
 }

--- a/api-server/main_test.go
+++ b/api-server/main_test.go
@@ -79,6 +79,10 @@ func TestShortenAPI(t *testing.T) {
 		}
 		var req ShortenRequest
 		json.NewDecoder(r.Body).Decode(&req)
+		if err := validateURL(req.URL); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
 		entry := store.Shorten(req.URL)
 		resp := ShortenResponse{
 			ShortURL:    "http://localhost:8080/r/" + entry.ShortCode,
@@ -107,6 +111,79 @@ func TestShortenAPI(t *testing.T) {
 	}
 }
 
+func TestShortenAPIInvalidURL(t *testing.T) {
+	store := NewStore("http://localhost:8080")
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/shorten", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		var req ShortenRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if err := validateURL(req.URL); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		entry := store.Shorten(req.URL)
+		resp := ShortenResponse{
+			ShortURL:    "http://localhost:8080/r/" + entry.ShortCode,
+			ShortCode:   entry.ShortCode,
+			OriginalURL: entry.OriginalURL,
+		}
+		writeJSON(w, http.StatusCreated, resp)
+	})
+
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{"空のURL", `{"url":""}`},
+		{"無効なURL", `{"url":"not-a-url"}`},
+		{"ftpスキーム", `{"url":"ftp://example.com"}`},
+		{"ホスト名なし", `{"url":"http://"}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := bytes.NewBufferString(tc.payload)
+			req := httptest.NewRequest(http.MethodPost, "/api/shorten", body)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected status 400 for %s, got %d", tc.name, w.Code)
+			}
+		})
+	}
+}
+
+func TestValidateURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"有効なhttps URL", "https://example.com", false},
+		{"有効なhttp URL", "http://example.com/path?q=1", false},
+		{"空文字列", "", true},
+		{"スキームなし", "example.com", true},
+		{"ftpスキーム", "ftp://example.com", true},
+		{"ホスト名なし", "http://", true},
+		{"無効な形式", "://invalid", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateURL(tc.url)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateURL(%q) error = %v, wantErr %v", tc.url, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestGetStats(t *testing.T) {
 	store := NewStore("http://localhost:8080")
 
@@ -116,5 +193,20 @@ func TestGetStats(t *testing.T) {
 	stats := store.GetStats()
 	if stats.TotalURLs != 2 {
 		t.Errorf("expected 2 total URLs, got %d", stats.TotalURLs)
+	}
+}
+
+func TestLoggingMiddleware(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	logged := loggingMiddleware(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	logged.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,18 @@ services:
     environment:
       - PORT=8080
       - BASE_URL=http://localhost:8080
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--spider", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   analytics:
     build: ./analytics
     depends_on:
-      - api-server
+      api-server:
+        condition: service_healthy
     environment:
       - API_URL=http://api-server:8080
     command: ["report", "--api-url", "http://api-server:8080"]
@@ -18,5 +25,6 @@ services:
   cli-client:
     build: ./cli-client
     depends_on:
-      - api-server
+      api-server:
+        condition: service_healthy
     command: ["stats", "--api-url", "http://api-server:8080"]


### PR DESCRIPTION
## 概要

Issue #4 で特定した改善点を実装しました。

## 変更内容

### Go APIサーバー (`api-server/main.go`)
- **URL妥当性検証を追加**: `validateURL` 関数を実装し、http/httpsスキームとホスト名の存在チェックを実施
- **HTTPアクセスログミドルウェアを追加**: `loggingMiddleware` と `responseWriter` ラッパーを実装し、全リクエストのメソッド・パス・ステータスコード・処理時間・送信元IPをログ出力

### テスト (`api-server/main_test.go`)
- `TestValidateURL`: URL検証関数の正常系・異常系テストを追加
- `TestShortenAPIInvalidURL`: 空URL・無効URL・ftpスキーム・ホスト名なしの場合に400が返ることをテスト
- `TestLoggingMiddleware`: ミドルウェアが正常に動作することをテスト

### Python アナリティクス (`analytics/client.py`)
- `APIError` 例外クラスを追加
- `ConnectionError`・`Timeout`・`HTTPError`・`RequestException` を個別にキャッチし、ユーザーフレンドリーな日本語エラーメッセージを表示

### アナリティクスCLI (`analytics/main.py`)
- `APIError` をキャッチして標準エラー出力に表示し、終了コード1で終了するように修正
- スタックトレースが表示されなくなった

### Docker Compose (`docker-compose.yml`)
- `api-server` サービスにヘルスチェックを追加（`/health` エンドポイントを10秒ごとに確認）
- `analytics` と `cli-client` サービスの `depends_on` を `condition: service_healthy` に更新

### 環境変数 (`.env.example`)
- 環境変数の説明と設定例を記載したファイルを追加

## テスト方法

```bash
# Go APIサーバーのテスト
cd api-server && go test ./...

# Python analyticsのテスト
cd analytics && python -m pytest test_analyzer.py
```

Closes #4