### PR TITLE
chore: GitHub Actions CI ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  api-server:
+    name: api-server (Go)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test -v -race ./...
+
+  cli-client:
+    name: cli-client (TypeScript)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli-client
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+  analytics:
+    name: analytics (Python)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: analytics
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install requests pytest
+
+      - name: Run tests
+        run: pytest test_analyzer.py -v


### PR DESCRIPTION
## 概要

Issue #6 で提案した GitHub Actions CI ワークフローを追加します。

## 変更内容

`.github/workflows/ci.yml` を新規作成し、以下の3ジョブを定義しました。

- **api-server**: Go 1.21 で `go vet ./...` および `go test -v -race ./...` を実行
- **cli-client**: Node.js 20 で `npm ci` → `npm run build` (tsc) → `npm test` を実行
- **analytics**: Python 3.11 で `pip install requests pytest` → `pytest test_analyzer.py -v` を実行

## トリガー

- `main` ブランチへの push
- 全ブランチへの pull_request

Closes #6