### PR TITLE
ショートコード衝突時のリトライ処理を追加

### DIFF
--- a/api-server/main.go
+++ b/api-server/main.go
@@ -62,17 +62,30 @@ func (s *Store) generateCode(rawURL string) string {
 }
 
 func (s *Store) Shorten(originalURL string) (*URLEntry, error) {
-	code := s.generateCode(originalURL)
-	entry := &URLEntry{}
-	err := s.db.QueryRow(
-		`INSERT INTO urls (short_code, original_url) VALUES ($1, $2)
-		 RETURNING short_code, original_url, created_at, clicks`,
-		code, originalURL,
-	).Scan(&entry.ShortCode, &entry.OriginalURL, &entry.CreatedAt, &entry.Clicks)
-	if err != nil {
-		return nil, err
+	const maxRetries = 5
+	for i := 0; i < maxRetries; i++ {
+		code := s.generateCode(originalURL)
+		entry := &URLEntry{}
+		err := s.db.QueryRow(
+			`INSERT INTO urls (short_code, original_url) VALUES ($1, $2)
+			 RETURNING short_code, original_url, created_at, clicks`,
+			code, originalURL,
+		).Scan(&entry.ShortCode, &entry.OriginalURL, &entry.CreatedAt, &entry.Clicks)
+		if err != nil {
+			// ユニーク制約違反（ショートコード衝突）の場合はリトライ
+			if strings.Contains(err.Error(), "duplicate key") ||
+				strings.Contains(err.Error(), "unique") {
+				log.Printf("ショートコード衝突 (試行 %d/%d): code=%s", i+1, maxRetries, code)
+				continue
+			}
+			return nil, err
+		}
+		if i > 0 {
+			log.Printf("ショートコード衝突回避成功: %d回目で生成 code=%s", i+1, code)
+		}
+		return entry, nil
 	}
-	return entry, nil
+	return nil, fmt.Errorf("ショートコード生成に%d回失敗しました（衝突が多すぎます）", maxRetries)
 }
 
 func (s *Store) Resolve(code string) (string, bool) {


### PR DESCRIPTION
## 変更概要
- `api-server/main.go`: `Shorten`メソッドに最大5回のリトライロジックを追加
- ユニーク制約違反（duplicate key / unique）をエラー文字列で検出
- 衝突発生と回避成功のログ出力を追加
- 5回全て衝突した場合は明示的なエラーメッセージを返す

## 対応Issue
Closes #11

## 動作確認手順
1. `cd api-server && go vet ./...` で静的解析通過を確認
2. `go test -v -race -timeout 120s ./...` で全テスト通過を確認
3. CI（PostgreSQL環境）でDB依存テストも通過することを確認