### PR TITLE
fix: GetStatsのエラーハンドリング追加

### DIFF
--- a/api-server/main.go
+++ b/api-server/main.go
@@ -104,14 +104,19 @@ func (s *Store) Resolve(code string) (string, bool) {
 func (s *Store) GetStats(limit, offset int) StatsResponse {
 	stats := StatsResponse{Entries: []URLEntry{}}
 
-	// Get total count first
-	s.db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(clicks), 0) FROM urls`).Scan(&stats.TotalURLs, &stats.TotalClicks)
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*), COALESCE(SUM(clicks), 0) FROM urls`,
+	).Scan(&stats.TotalURLs, &stats.TotalClicks); err != nil {
+		log.Printf("統計集計クエリ失敗: %v", err)
+		return stats
+	}
 
 	rows, err := s.db.Query(
 		`SELECT short_code, original_url, created_at, clicks FROM urls ORDER BY created_at DESC LIMIT $1 OFFSET $2`,
 		limit, offset,
 	)
 	if err != nil {
+		log.Printf("統計一覧クエリ失敗: %v", err)
 		return stats
 	}
 	defer rows.Close()
@@ -119,9 +124,13 @@ func (s *Store) GetStats(limit, offset int) StatsResponse {
 	for rows.Next() {
 		var entry URLEntry
 		if err := rows.Scan(&entry.ShortCode, &entry.OriginalURL, &entry.CreatedAt, &entry.Clicks); err != nil {
+			log.Printf("統計行スキャン失敗: %v", err)
 			continue
 		}
 		stats.Entries = append(stats.Entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("統計行イテレーションエラー: %v", err)
 	}
 	return stats
 }


### PR DESCRIPTION
## 変更概要

- `GetStats()` の `QueryRow.Scan` にエラーチェックとログ出力を追加
- `rows.Next()` ループ後に `rows.Err()` チェックを追加
- 行スキャン失敗時にもログ出力を追加

Closes #18

## 動作確認手順
1. `cd api-server && go vet ./...` でコード品質チェック通過を確認
2. `go build ./...` でビルド成功を確認
3. PostgreSQL環境で `go test -v -race ./...` を実行して全テスト通過を確認

## 補足: CI修正（手動対応が必要）
マージ後、`.github/workflows/ci.yml` の87行目を以下のように修正してください:
```yaml
# 変更前
run: pytest test_analyzer.py -v
# 変更後
run: pytest test_*.py -v
```
これにより `test_client.py` の17件のテストもCIで実行されるようになります。