### PR TITLE
fix: ショートコード形式のバリデーション追加

### DIFF
--- a/api-server/graceful_test.go
+++ b/api-server/graceful_test.go
@@ -31,3 +31,27 @@ func TestMaxURLLengthConstant(t *testing.T) {
 		t.Errorf("expected maxURLLength=2048, got %d", maxURLLength)
 	}
 }
+
+func TestValidShortCode(t *testing.T) {
+	tests := []struct {
+		code  string
+		valid bool
+	}{
+		{"abcdef12", true},
+		{"00112233", true},
+		{"aabbccdd", true},
+		{"", false},
+		{"short", false},
+		{"toolongcode123", false},
+		{"ABCDEF12", false},
+		{"abcdefg!", false},
+		{"../../../", false},
+		{"abcdefgh", false},
+	}
+	for _, tc := range tests {
+		got := validShortCode.MatchString(tc.code)
+		if got != tc.valid {
+			t.Errorf("validShortCode(%q) = %v, want %v", tc.code, got, tc.valid)
+		}
+	}
+}

--- a/api-server/main.go
+++ b/api-server/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"regexp"
 	"net/http"
 	"net/url"
 	"os"
@@ -26,6 +27,8 @@ import (
 var indexHTML []byte
 
 const maxURLLength = 2048
+
+var validShortCode = regexp.MustCompile(`^[a-f0-9]{8}$`)
 
 type URLEntry struct {
 	OriginalURL string    `json:"original_url"`
@@ -468,6 +471,10 @@ func main() {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "short code required"})
 			return
 		}
+		if !validShortCode.MatchString(code) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid short code format"})
+			return
+		}
 
 		originalURL, ok := store.Resolve(code)
 		if !ok {
@@ -507,6 +514,10 @@ func main() {
 			return
 		}
 		code := r.URL.Path[len("/api/stats/"):]
+		if !validShortCode.MatchString(code) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid short code format"})
+			return
+		}
 		entry, ok := store.GetEntry(code)
 		if !ok {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "short url not found"})


### PR DESCRIPTION
## 変更概要

- ショートコードの正規表現バリデーション `^[a-f0-9]{8}$` を追加
- `/r/{code}` リダイレクトと `/api/stats/{code}` の両方で不正なコード形式を400エラーで拒否
- パストラバーサルやSQLインジェクション的な入力を事前にブロック

Closes #21

## 動作確認手順

1. `go test -v -race -run TestValidShortCode ./...` でバリデーションテストがパスすること
2. `curl http://localhost:8080/r/../../../etc/passwd` で400エラーが返ること
3. `curl http://localhost:8080/r/abcdef12` で正常にリダイレクト（またはnot found）されること