### PR TITLE
セキュリティ強化: ReadHeaderTimeout追加とリクエストボディサイズ制限

### DIFF
--- a/api-server/main.go
+++ b/api-server/main.go
@@ -362,6 +362,18 @@ func rateLimitMiddleware(rl *RateLimiter, next http.Handler) http.Handler {
 	})
 }
 
+const maxRequestBodySize = 1 << 20 // 1MB
+
+// maxBodySizeMiddleware はリクエストボディのサイズを制限するミドルウェア
+func maxBodySizeMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost || r.Method == http.MethodPut {
+			r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // loggingMiddleware はHTTPリクエストをログ出力するミドルウェア
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -527,11 +539,12 @@ func main() {
 	})
 
 	srv := &http.Server{
-		Addr:         ":" + port,
-		Handler:      loggingMiddleware(mux),
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 30 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:              ":" + port,
+		Handler:           maxBodySizeMiddleware(loggingMiddleware(mux)),
+		ReadTimeout:       10 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	quit := make(chan os.Signal, 1)

--- a/api-server/main_test.go
+++ b/api-server/main_test.go
@@ -621,3 +621,45 @@ func TestLoggingMiddleware(t *testing.T) {
 		t.Errorf("expected status 200, got %d", w.Code)
 	}
 }
+
+func TestMaxBodySizeMiddleware(t *testing.T) {
+	handler := maxBodySizeMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var data map[string]string
+		err := json.NewDecoder(r.Body).Decode(&data)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body too large"})
+			return
+		}
+		writeJSON(w, http.StatusOK, data)
+	}))
+
+	t.Run("正常サイズのボディは通過する", func(t *testing.T) {
+		body := bytes.NewBufferString(`{"url":"https://example.com"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/shorten", body)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("GETリクエストはボディサイズ制限を受けない", func(t *testing.T) {
+		getHandler := maxBodySizeMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+		getHandler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestMaxRequestBodySizeConstant(t *testing.T) {
+	if maxRequestBodySize != 1<<20 {
+		t.Errorf("expected maxRequestBodySize to be 1MB (1048576), got %d", maxRequestBodySize)
+	}
+}


### PR DESCRIPTION
## 変更概要
- `api-server/main.go`: `ReadHeaderTimeout: 5 * time.Second` を追加してSlowloris攻撃を緩和
- `api-server/main.go`: `maxBodySizeMiddleware` を追加し、POST/PUTリクエストのボディサイズを1MBに制限
- `api-server/main_test.go`: ボディサイズ制限ミドルウェアのテスト3件を追加

Closes #24

## 動作確認手順
1. `go build ./...` でビルドが成功すること
2. `go test -v -race ./...` で全テストがパスすること
3. `go vet ./...` で警告がないこと